### PR TITLE
Expose unsafe methods

### DIFF
--- a/src/Standart.Hash.xxHash/xxHash32.Unsafe.cs
+++ b/src/Standart.Hash.xxHash/xxHash32.Unsafe.cs
@@ -18,7 +18,7 @@
         /// <param name="seed"></param>
         /// <returns></returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static unsafe uint UnsafeComputeHash(byte* ptr, int length, uint seed)
+        public static unsafe uint UnsafeComputeHash(byte* ptr, int length, uint seed)
         {
             byte* end = ptr + length;
             uint h32;

--- a/src/Standart.Hash.xxHash/xxHash64.Unsafe.cs
+++ b/src/Standart.Hash.xxHash/xxHash64.Unsafe.cs
@@ -18,7 +18,7 @@
         /// <param name="seed"></param>
         /// <returns></returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static unsafe ulong UnsafeComputeHash(byte* ptr, int length, ulong seed)
+        public static unsafe ulong UnsafeComputeHash(byte* ptr, int length, ulong seed)
         {
             byte* end = ptr + length;
             ulong h64;


### PR DESCRIPTION
I understand having these methods private but when you want to optimize performance, using the unsafe methods is the only choice.