### PR TITLE
Set PackageLicenseExpression to MIT

### DIFF
--- a/nuget.props
+++ b/nuget.props
@@ -10,5 +10,6 @@
     <PackageTags>hash;xxHash</PackageTags>
     <Description>Standart.Hash.xxHash</Description>
     <PackageProjectUrl>https://github.com/uranium62/xxHash</PackageProjectUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
There are some security tools that are giving license issues (warnings) to .nuget packages that are missing license info. And it seems that creators of those tool do not want to fetch the license info from other sources. So this PR adds that info to the .nuget package and hopefully those tools won't complain anymore. 