### PR TITLE
Bmi2.X64.MultiplyNoFlags only x64

### DIFF
--- a/src/Standart.Hash.xxHash/xxHash128.XXH.cs
+++ b/src/Standart.Hash.xxHash/xxHash128.XXH.cs
@@ -97,7 +97,7 @@ namespace Standart.Hash.xxHash
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static uint128 XXH_mult64to128(ulong lhs, ulong rhs)
         {
-            if (Bmi2.IsSupported)
+            if (Bmi2.X64.IsSupported)
                 return XXH_mult64to128_bmi2(lhs, rhs);
             
             return XXH_mult64to128_scalar(lhs, rhs);

--- a/src/Standart.Hash.xxHash/xxHash3.XXH.cs
+++ b/src/Standart.Hash.xxHash/xxHash3.XXH.cs
@@ -96,7 +96,7 @@ namespace Standart.Hash.xxHash
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static uint128 XXH_mult64to128(ulong lhs, ulong rhs)
         {
-            if (Bmi2.IsSupported)
+            if (Bmi2.X64.IsSupported)
                 return XXH_mult64to128_bmi2(lhs, rhs);
 
             return XXH_mult64to128_scalar(lhs, rhs);


### PR DESCRIPTION
Bmi2.X64.MultiplyNoFlags can't use for x86